### PR TITLE
chore: Tidy up container architecture logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,23 +42,13 @@ jib {
     from {
         image = "azul/zulu-openjdk-alpine:${javaTarget}-jre"
         platforms {
-            // We can only build multi-arch images when pushing to a registry, not when building locally
-            def requestedTasks = gradle.startParameter.taskNames
-            if ('jibBuildTar' in requestedTasks || 'jibDockerBuild' in requestedTasks) {
-                platform {
-                    // todo: better logic
-                    architecture = System.getProperty('os.arch') == 'aarch64' ? 'arm64' : 'amd64'
-                    os = 'linux'
-                }
-            } else {
-                platform {
-                    architecture = 'amd64'
-                    os = 'linux'
-                }
-                platform {
-                    architecture = 'arm64'
-                    os = 'linux'
-                }
+            platform {
+                architecture = 'amd64'
+                os = 'linux'
+            }
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ goomph = "4.0.1"
 immutables = "2.10.1"
 indra = "3.1.3"
 tinylog = "2.7.0"
-jib = "3.4.0"
+jib = "3.4.3"
 
 [libraries]
 discordWebhooks = { module = "club.minnced:discord-webhooks", version = "0.8.4" }


### PR DESCRIPTION
We previously changed which architectures were built based on the requested tasks. This is rather messy though, and Jib should have added new functionality to automatically align with the running docker daemon.

Unfortunately this new feature doesn't work with Podman because of output differences, so it's not yet mergable.